### PR TITLE
Visual Studio install

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,16 @@ After generating project files using the OF Project Generator, add the following
 $OF_PATH/addons/ofxTensorFlow2/scripts/macos_install_libs.sh "$TARGET_BUILD_DIR/$PRODUCT_NAME.app";
 ```
 
+### Windows / Visual Studio 2022
+
+1. Install CUDA 11.7
+2. Install CUDNN 8.4.1.50
+3. Install Zlib
+4. Put the files from C:\Program Files\NVIDIA GPU Computing Toolkit\CUDNN\v8.4.1.50\bin and zlibwapi.dll into C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin
+5. Install Tensorflow for GPU with the included script:
+TYPE=gpu ./scripts/download_tensorflow.sh 2.9.0
+6. Rename ofxTensorFlow2\libs\tensorflow\lib\msys to ofxTensorFlow2\libs\tensorflow\lib\vs.
+
 #### Makefile build
 
 Enable C++14 features by changing `-std=c++11` to `-std=c++14` on line 142 in `OF_ROOT/libs/openFrameworksCompiled/project/osx/config.osx.default.mk`:

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ $OF_PATH/addons/ofxTensorFlow2/scripts/macos_install_libs.sh "$TARGET_BUILD_DIR/
 4. Put the files from C:\Program Files\NVIDIA GPU Computing Toolkit\CUDNN\v8.4.1.50\bin and zlibwapi.dll into C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin
 5. Install Tensorflow for GPU with the included script:
 TYPE=gpu ./scripts/download_tensorflow.sh 2.9.0
-6. Rename ofxTensorFlow2\libs\tensorflow\lib\msys to ofxTensorFlow2\libs\tensorflow\lib\vs.
+6. Rename ofxTensorFlow2\libs\tensorflow\lib\msys to ofxTensorFlow2\libs\tensorflow\lib\vs
 
 #### Makefile build
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ $OF_PATH/addons/ofxTensorFlow2/scripts/macos_install_libs.sh "$TARGET_BUILD_DIR/
 3. Put the files from C:\Program Files\NVIDIA GPU Computing Toolkit\CUDNN\v8.4.1.50\bin and zlibwapi.dll from http://www.winimage.com/zLibDll/zlib123dllx64.zip into C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin
 4. Put https://github.com/serizba/cppflow into ofxTensorFlow2\libs\cppflow
 5. Put libtensorflow-gpu-windows-x86_64-2.8.0 from https://www.tensorflow.org/install/lang_c into ofxTensorFlow2\libs\tensorflow
-6. Run ofxTensorFlow2\scripts\download_example_models.sh
+6. Create a folder ofxTensorFlow2\libs\tensorflow\lib\vs and put the content from ofxTensorFlow2\libs\tensorflow\lib (2 files) there.
+7. Run ofxTensorFlow2\scripts\download_example_models.sh
 
 #### Makefile build
 

--- a/README.md
+++ b/README.md
@@ -202,10 +202,9 @@ $OF_PATH/addons/ofxTensorFlow2/scripts/macos_install_libs.sh "$TARGET_BUILD_DIR/
 
 1. Install CUDA 11.7
 2. Install CUDNN 8.4.1.50
-3. Install Zlib
-4. Put the files from C:\Program Files\NVIDIA GPU Computing Toolkit\CUDNN\v8.4.1.50\bin and zlibwapi.dll into C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin
-5. Put https://github.com/serizba/cppflow into ofxTensorFlow2\libs\cppflow
-6. Put libtensorflow-gpu-windows-x86_64-2.8.0 from https://www.tensorflow.org/install/lang_c into ofxTensorFlow2\libs\tensorflow
+3. Put the files from C:\Program Files\NVIDIA GPU Computing Toolkit\CUDNN\v8.4.1.50\bin and zlibwapi.dll from http://www.winimage.com/zLibDll/zlib123dllx64.zip into C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin
+4. Put https://github.com/serizba/cppflow into ofxTensorFlow2\libs\cppflow
+5. Put libtensorflow-gpu-windows-x86_64-2.8.0 from https://www.tensorflow.org/install/lang_c into ofxTensorFlow2\libs\tensorflow
 
 #### Makefile build
 

--- a/README.md
+++ b/README.md
@@ -204,9 +204,8 @@ $OF_PATH/addons/ofxTensorFlow2/scripts/macos_install_libs.sh "$TARGET_BUILD_DIR/
 2. Install CUDNN 8.4.1.50
 3. Install Zlib
 4. Put the files from C:\Program Files\NVIDIA GPU Computing Toolkit\CUDNN\v8.4.1.50\bin and zlibwapi.dll into C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin
-5. Install Tensorflow for GPU with the included script:
-TYPE=gpu ./scripts/download_tensorflow.sh 2.9.0
-6. Rename ofxTensorFlow2\libs\tensorflow\lib\msys to ofxTensorFlow2\libs\tensorflow\lib\vs
+5. Put https://github.com/serizba/cppflow into ofxTensorFlow2\libs\cppflow
+6. Put libtensorflow-gpu-windows-x86_64-2.8.0 from https://www.tensorflow.org/install/lang_c into ofxTensorFlow2\libs\tensorflow
 
 #### Makefile build
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ $OF_PATH/addons/ofxTensorFlow2/scripts/macos_install_libs.sh "$TARGET_BUILD_DIR/
 3. Put the files from C:\Program Files\NVIDIA GPU Computing Toolkit\CUDNN\v8.4.1.50\bin and zlibwapi.dll from http://www.winimage.com/zLibDll/zlib123dllx64.zip into C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin
 4. Put https://github.com/serizba/cppflow into ofxTensorFlow2\libs\cppflow
 5. Put libtensorflow-gpu-windows-x86_64-2.8.0 from https://www.tensorflow.org/install/lang_c into ofxTensorFlow2\libs\tensorflow
+6. Run ofxTensorFlow2\scripts\download_example_models.sh
 
 #### Makefile build
 


### PR DESCRIPTION
I added this to the readme:
```
### Windows / Visual Studio 2022

1. Install CUDA 11.7
2. Install CUDNN 8.4.1.50
3. Put the files from C:\Program Files\NVIDIA GPU Computing Toolkit\CUDNN\v8.4.1.50\bin and zlibwapi.dll from http://www.winimage.com/zLibDll/zlib123dllx64.zip into C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin
4. Put https://github.com/serizba/cppflow into ofxTensorFlow2\libs\cppflow
5. Put libtensorflow-gpu-windows-x86_64-2.8.0 from https://www.tensorflow.org/install/lang_c into ofxTensorFlow2\libs\tensorflow
6. Create the folder ofxTensorFlow2\libs\tensorflow\lib\vs and put the content from ofxTensorFlow2\libs\tensorflow\lib (2 files) there.
7. Run ofxTensorFlow2\scripts\download_example_models.sh
```
Installed it a second time to confirm that it works for me.
Not sure if this is the right format, just wanted to share it because its working for me.